### PR TITLE
Add basic API and React client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # VranjicReact
-net w react
+
+This project contains a simple ASP.NET Core REST API and a lightweight React frontend. The API uses Entity Framework Core with SQL Server. The React files live in `client/` and can be copied to the repository root via `./build.sh` for FTP deployment.
+
+## Building the API
+
+```bash
+cd VranjicApi
+# restore and build (requires access to NuGet)
+dotnet build
+```
+
+## Building the frontend
+
+```bash
+./build.sh
+```

--- a/VranjicApi/Data/VranjicContext.cs
+++ b/VranjicApi/Data/VranjicContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using VranjicApi.Models;
+
+namespace VranjicApi.Data
+{
+    public class VranjicContext : DbContext
+    {
+        public VranjicContext(DbContextOptions<VranjicContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<News> News { get; set; } = default!;
+        public DbSet<BlogPost> BlogPosts { get; set; } = default!;
+        public DbSet<GalleryImage> GalleryImages { get; set; } = default!;
+        public DbSet<ContactMessage> ContactMessages { get; set; } = default!;
+    }
+}

--- a/VranjicApi/Models/BlogPost.cs
+++ b/VranjicApi/Models/BlogPost.cs
@@ -1,0 +1,10 @@
+namespace VranjicApi.Models
+{
+    public class BlogPost
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public DateTime Date { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/VranjicApi/Models/ContactMessage.cs
+++ b/VranjicApi/Models/ContactMessage.cs
@@ -1,0 +1,11 @@
+namespace VranjicApi.Models
+{
+    public class ContactMessage
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public DateTime Date { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/VranjicApi/Models/GalleryImage.cs
+++ b/VranjicApi/Models/GalleryImage.cs
@@ -1,0 +1,9 @@
+namespace VranjicApi.Models
+{
+    public class GalleryImage
+    {
+        public int Id { get; set; }
+        public string Url { get; set; } = string.Empty;
+        public string Caption { get; set; } = string.Empty;
+    }
+}

--- a/VranjicApi/Models/News.cs
+++ b/VranjicApi/Models/News.cs
@@ -1,0 +1,10 @@
+namespace VranjicApi.Models
+{
+    public class News
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public DateTime Date { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/VranjicApi/Program.cs
+++ b/VranjicApi/Program.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using VranjicApi.Data;
+using VranjicApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddEndpointsApiExplorer();
+
+builder.Services.AddDbContext<VranjicContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+app.MapGet("/novosti", async (VranjicContext db) => await db.News.ToListAsync());
+app.MapPost("/novosti", async (News news, VranjicContext db) => { db.News.Add(news); await db.SaveChangesAsync(); return Results.Created($"/novosti/{news.Id}", news); });
+
+app.MapGet("/blog", async (VranjicContext db) => await db.BlogPosts.ToListAsync());
+app.MapPost("/blog", async (BlogPost post, VranjicContext db) => { db.BlogPosts.Add(post); await db.SaveChangesAsync(); return Results.Created($"/blog/{post.Id}", post); });
+
+app.MapGet("/galerija", async (VranjicContext db) => await db.GalleryImages.ToListAsync());
+app.MapPost("/galerija", async (GalleryImage img, VranjicContext db) => { db.GalleryImages.Add(img); await db.SaveChangesAsync(); return Results.Created($"/galerija/{img.Id}", img); });
+
+app.MapPost("/kontakt", async (ContactMessage msg, VranjicContext db) => { db.ContactMessages.Add(msg); await db.SaveChangesAsync(); return Results.Created($"/kontakt/{msg.Id}", msg); });
+
+app.Run();

--- a/VranjicApi/Properties/launchSettings.json
+++ b/VranjicApi/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:24238",
+      "sslPort": 44334
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5268",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7216;http://localhost:5268",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/VranjicApi/VranjicApi.csproj
+++ b/VranjicApi/VranjicApi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/VranjicApi/VranjicApi.http
+++ b/VranjicApi/VranjicApi.http
@@ -1,0 +1,6 @@
+@VranjicApi_HostAddress = http://localhost:5268
+
+GET {{VranjicApi_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/VranjicApi/appsettings.Development.json
+++ b/VranjicApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/VranjicApi/appsettings.json
+++ b/VranjicApi/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=VranjicDb;Trusted_Connection=True;"
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Simple build script to copy static React files to repo root for FTP deploy
+cp client/index.html ./
+cp client/app.js ./

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,21 @@
+const e = React.createElement;
+
+function App() {
+  return e('div', null,
+    e('header', null,
+      e('nav', null,
+        e('a', {href: '#novosti'}, 'Novosti'),
+        e('a', {href: '#onama'}, 'O nama'),
+        e('a', {href: '#kontakt'}, 'Kontakt'),
+        e('a', {href: '#galerija'}, 'Galerija'),
+        e('a', {href: '#blog'}, 'Blog')
+      )
+    ),
+    e('main', null,
+      e('h1', null, 'Dobrodošli u Vranjic!'),
+      e('p', null, 'Malo mjesto pokraj Splita s morem, kamenjem i alpinima.')
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="hr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Vranjic</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; background: #eef5fb; color: #333; }
+    header { background: #004e7c; color: white; padding: 1rem; }
+    nav a { margin-right: 1rem; color: white; text-decoration: none; }
+    main { padding: 1rem; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create ASP.NET Core API project with EF Core context and minimal endpoints
- add React client using CDN with simple navigation
- add deployment script and update README

## Testing
- `dotnet build` *(fails: Failed to retrieve information about 'Microsoft.EntityFrameworkCore.SqlServer' from remote source)*

------
https://chatgpt.com/codex/tasks/task_e_6862445c08f48332b1a1268563cd9cbc